### PR TITLE
Bump enonic libs for XP 8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 http-client   = "3.2.2"
 google-cse    = "2.0.0"
 thymeleaf     = "3.0.0-SNAPSHOT"
-util          = "3.1.1"
+util          = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "http-client" }


### PR DESCRIPTION
## Summary

Pin `lib-util` to the next-major SNAPSHOT published from its master branch. The lib has been upgraded to XP 8 (xpVersion 8.0.0-B4) but is not yet released — consumers pin to the SNAPSHOT for now.

### Libs bumped

| Lib | Before | After |
|---|---|---|
| `com.enonic.lib:lib-util` | `3.1.1` (release) | `4.0.0-SNAPSHOT` (resolves from `xp.enonicRepo('dev')`) |

(Only `lib-util` is consumed by this repo from the XP-8 lib set; `lib-menu` and `lib-explorer` are not used here.)

### Excludes removed

None — `lib-util` has no `exclude` clauses on it in `build.gradle`, so there was nothing to audit/remove.

### Excludes kept

None applicable. (The unrelated `exclude group: 'com.enonic.xp'` on `lib-google-cse` is untouched and out of scope for this PR.)

### Snapshot repo declaration

Already present in `build.gradle`:
```gradle
repositories {
    mavenLocal()
    mavenCentral()
    xp.enonicRepo('dev')
}
```
No change needed.

## Test plan

- [x] `./gradlew dependencies --configuration include` resolves `com.enonic.lib:lib-util:4.0.0-SNAPSHOT` cleanly with no transitive deps
- [x] `./gradlew clean build` succeeds
- [ ] Runtime verification was not performed

🤖 Generated with [Claude Code](https://claude.com/claude-code)