### PR TITLE
Bump lib-http-client to 4.0.0-SNAPSHOT

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 http-client   = "3.2.2"
 google-cse    = "2.0.0"
 thymeleaf     = "3.0.0-SNAPSHOT"
-util          = "3.1.1"
+util          = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "http-client" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-http-client   = "3.2.2"
+http-client   = "4.0.0-SNAPSHOT"
 google-cse    = "2.0.0"
 thymeleaf     = "3.0.0-SNAPSHOT"
 util          = "4.0.0-SNAPSHOT"


### PR DESCRIPTION
## Summary

Follow-up to #38. `lib-http-client` master has been upgraded to XP 8; pin this app to `4.0.0-SNAPSHOT` (resolves from `xp.enonicRepo('dev')`, already declared).

`lib-thymeleaf` was already on `3.0.0-SNAPSHOT` from the original XP 8 upgrade in #37, so no change needed there.

### Libs bumped

| Lib | Before | After |
|---|---|---|
| `com.enonic.lib:lib-http-client` | `3.2.2` (release) | `4.0.0-SNAPSHOT` (resolves from `xp.enonicRepo('dev')`) |

### Excludes removed

None — `lib-http-client` is consumed as plain `include(libs.lib.http.client)` with no `exclude` clause to strip.

### Excludes kept

`lib-google-cse`'s `exclude group: 'com.enonic.xp'` is intentionally retained. `lib-google-cse` has no source repo in the `enonic` org and has not been upgraded to XP 8 — its transitive XP deps are still XP-7-pinned and the exclude remains load-bearing.

## Note

The original task asked for this commit to land on PR #38, but #38 was already merged before the commit was prepared. Opening this as a follow-up PR is the only way to deliver the change.

## Test plan

- [x] `./gradlew clean build` succeeds
- [x] `./gradlew dependencies --configuration include --refresh-dependencies` resolves `lib-http-client:4.0.0-SNAPSHOT` cleanly with no `com.enonic.xp:*` leakage from it (or from `lib-thymeleaf:3.0.0-SNAPSHOT`)
- [ ] Runtime verification not performed

🤖 Generated with [Claude Code](https://claude.com/claude-code)