### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ group = com.enonic.app
 projectName = google-cse
 appName = com.enonic.app.google.cse
 xpVersion = 8.0.0-B4
-version = 2.1.0-SNAPSHOT
+version = 3.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

- Bump `version` in `gradle.properties` from `2.1.0-SNAPSHOT` to `3.0.0-SNAPSHOT` to start the XP 8 line on master.
- Add `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `2.x` so the release-tooling action recognizes both as release branches.

The `2.x` branch is the XP 7 maintenance line, branched at the post-`v2.0.0` SNAPSHOT-bump commit (`d3aeb11`, `version=2.1.0-SNAPSHOT`).

A companion PR against `2.x` adds the same `releaseBranch:` block on that branch (the action reads the config from each branch's own workflow file).

## Test plan

- [ ] CI green on `chore/bump-to-next-major`
- [ ] After merge, CI on `master` continues to be classified as a release branch