### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -1,0 +1,29 @@
+name: Gradle Build
+
+on: [ push ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.build-and-publish.outputs.release }}
+    steps:
+      - id: build-and-publish
+        uses: enonic/release-tools/build-and-publish@master
+        with:
+          repoUser: ci
+          repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
+
+  release:
+    runs-on: ubuntu-latest
+
+    needs: build
+    if: needs.build.outputs.release == 'true'
+
+    steps:
+      - uses: enonic/release-tools/release@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `.github/workflows/enonic-gradle.yml` on the new `2.x` maintenance branch with a `releaseBranch:` block listing both `master` and `2.x`.
- The release-tooling action reads `releaseBranch:` from each branch's own workflow file, so this PR is required for pushes to `2.x` to be classified as release-branch builds.

The companion master PR (#40) bumps `version` to `3.0.0-SNAPSHOT` and adds the same `releaseBranch:` block on master. This branch (`2.x`) was branched at SHA `d3aeb11` (post-`v2.0.0` SNAPSHOT bump, `version=2.1.0-SNAPSHOT`, `xpVersion=7.0.0`). The workflow file did not exist at that point in history, so this PR creates it from scratch matching master's current shape.

No version bump or other master-only changes are included here.

## Test plan

- [ ] After merge, a CI run on `2.x` is classified as a release branch