### PR TITLE
Drop lib-util

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     include libs.lib.http.client
     include libs.lib.google.cse
     include libs.lib.thymeleaf
-    include libs.lib.util
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,10 +2,8 @@
 http-client   = "4.0.0-SNAPSHOT"
 google-cse    = "2.0.0"
 thymeleaf     = "3.0.0-SNAPSHOT"
-util          = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "http-client" }
 lib-google-cse  = { module = "com.enonic.lib:lib-google-cse",  version.ref = "google-cse" }
 lib-thymeleaf   = { module = "com.enonic.lib:lib-thymeleaf",   version.ref = "thymeleaf" }
-lib-util        = { module = "com.enonic.lib:lib-util",        version.ref = "util" }

--- a/src/main/resources/cms/parts/customSearchresult/customSearchresult.js
+++ b/src/main/resources/cms/parts/customSearchresult/customSearchresult.js
@@ -2,8 +2,7 @@ var lib = {
     thymeleaf: require('/lib/thymeleaf'),
     portal: require('/lib/xp/portal'),
     cse: require('/lib/cse'),
-    cseutil: require('/lib/cse-util'),
-    util: require('/lib/util')
+    cseutil: require('/lib/cse-util')
 };
 
 
@@ -29,7 +28,7 @@ exports.get = function( req ){
     else {
         if(cc.resultfield){
             var hits = mapResultToConfiguratedFields({
-                fields: lib.util.data.forceArray(cc.resultfield),
+                fields: (Array.isArray(cc.resultfield) ? cc.resultfield : [cc.resultfield]),
                 items: searchResult.items
             });
 

--- a/src/main/resources/cms/parts/searchresult/searchresult.js
+++ b/src/main/resources/cms/parts/searchresult/searchresult.js
@@ -1,6 +1,5 @@
 var lib = {
     thymeleaf: require('/lib/thymeleaf'),
-    util: require('/lib/util'),
     portal: require('/lib/xp/portal'),
     cse: require('/lib/cse'),
     gu: require('/lib/cse-util')
@@ -39,7 +38,7 @@ exports.get = function( req ){
 
 /* Soon to be used */
 function hasComponent(page, componentName){
-    var regions = lib.util.data.forceArray(page.regions);
+    var regions = (Array.isArray(page.regions) ? page.regions : [page.regions]);
     for(var i = 0; i < regions.length; i ++){
         var components = lig.util.data.forecArray(regions[i].components);
     }


### PR DESCRIPTION
## Summary

Inlines the only `lib-util` call site (`util.data.forceArray`) using the Nashorn-safe `Array.isArray(x) ? x : [x]` pattern, then removes `lib-util` from `build.gradle` and `gradle/libs.versions.toml`.

Replacements applied:

| call | inlined replacement |
|---|---|
| `lib.util.data.forceArray(x)` | `(Array.isArray(x) ? x : [x])` |

Files touched:

- `src/main/resources/cms/parts/customSearchresult/customSearchresult.js` — dropped `util` from `lib` and inlined the `forceArray(cc.resultfield)` call.
- `src/main/resources/cms/parts/searchresult/searchresult.js` — dropped `util` from `lib` and inlined the `forceArray(page.regions)` call inside the dead `hasComponent` helper (marked `/* Soon to be used */`). The line below it (`lig.util.data.forecArray(...)`) is a pre-existing typo on a non-existent `lig` identifier — left untouched per the "don't refactor unrelated parts" rule.
- `build.gradle` — removed `include libs.lib.util`.
- `gradle/libs.versions.toml` — removed the `util` version and the `lib-util` library entry.

## Pre-existing build failure (not caused by this PR)

`./gradlew build` fails identically on master with:

```
Could not resolve com.enonic.xp:lib-io:7.0.0.
  Required by:
      root project 'google-cse' > com.enonic.lib:lib-google-cse:2.0.0
   > Included dependency com.enonic.xp:lib-io:7.0.0 is incompatible with app systemVersion 8.0.0-B4
```

`lib-google-cse:2.0.0` pulls XP 7's `lib-io:7.0.0` transitively, which XP 8 rejects. There is already an open branch (`fix/lib-google-cse-xp7-transitive-exclude`) tracking this. Out of scope for this PR.

## Test plan

- [ ] CI: green once the pre-existing `lib-google-cse` transitive issue is resolved on master.
- [ ] Manual: behavior is byte-identical to prior `forceArray(x)` for arrays, scalars, and `null` (all three branches map the same way — `null` becomes `[null]`, matching lib-util semantics).